### PR TITLE
Fix regex error when searching for AndroidManifest in Windows

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -68,8 +68,8 @@ async function downloadSelendroid () {
 async function getFilePathFromJar (fileRegex, jarPath) {
   let {stdout} = await exec('jar', ['tf', jarPath]);
   for (let line of stdout.split("\n")) {
-    if (fileRegex.test(line)) {
-      return line;
+    if (fileRegex.test(line.trim())) {
+      return line.trim();
     }
   }
   throw new Error(`Could not find ${fileRegex} in ${jarPath}`);


### PR DESCRIPTION
The installation of Appium 1.5 from source in Windows 10 fails with this error:

```   
Error: Could not find /AndroidManifest.*\.xml$/ in D:\appium\node_modules\appium-selendroid-driver\node_modules\appium-selendroid-installer\selendroid\download\selendroid-server.jar
```

The error cause is that the files names returned by 'jar tf' command have a space after the name, at least in Windows 10.
